### PR TITLE
Acrescenta link do Calendly

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ O menu de serviços da Célere inclui:
 
 A melhor parte? É muito provável que os nossos serviços tenham melhor custo-benefício que sua solução atual para rodar o WordPress.
 
-[Vamos conversar?](mailto:contato@celere.dev)
+[Vamos conversar?](https://calendly.com/celere-dev/conversa)
 
 ***
 


### PR DESCRIPTION
Aproveitei para alterar a URL da nossa conta no Calendly para o padrão `celere-dev`, renomear o agendador de “mapeamento” para “conversa” e programar a janela de datas disponíveis para os próximos 15 dias úteis.

Se puder, quando tiver um tempo [simule um agendamento](https://calendly.com/celere-dev/conversa), só para nos certificarmos de que está tudo certo.